### PR TITLE
Guard Float16 usage with arm64 architecture check

### DIFF
--- a/swift/source/SimSIMD.swift
+++ b/swift/source/SimSIMD.swift
@@ -14,6 +14,7 @@ extension Int8: SimSIMD {
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
 
+#if arch(arm64)
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 extension Float16: SimSIMD {
     public static let dataType = simsimd_datatype_f16_k
@@ -21,6 +22,7 @@ extension Float16: SimSIMD {
     public static let dotProduct = find(kind: simsimd_metric_dot_k, dataType: dataType)
     public static let squaredEuclidean = find(kind: simsimd_metric_sqeuclidean_k, dataType: dataType)
 }
+#endif
 
 extension Float32: SimSIMD {
     public static let dataType = simsimd_datatype_f32_k

--- a/swift/tests/SimSIMDTests.swift
+++ b/swift/tests/SimSIMDTests.swift
@@ -13,12 +13,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 0.00012027938, accuracy: 0.01)
     }
 
+#if arch(arm64)
     func testCosineFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [1.0, 2.0, 3.0]
         let result = try XCTUnwrap(a.cosine(b))
         XCTAssertEqual(result, 0.004930496, accuracy: 0.01)
     }
+#endif
 
     func testCosineFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]
@@ -41,12 +43,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 0.029403687, accuracy: 0.01)
     }
 
+#if arch(arm64)
     func testDotFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [4.0, 5.0, 6.0]
         let result = try XCTUnwrap(a.dot(b))
         XCTAssertEqual(result, 32.0, accuracy: 0.01)
     }
+#endif
 
     func testDotFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]
@@ -69,12 +73,14 @@ class SimSIMDTests: XCTestCase {
         XCTAssertEqual(result, 27.0, accuracy: 0.01)
     }
 
+#if arch(arm64)
     func testSqeuclideanFloat16() throws {
         let a: [Float16] = [1.0, 2.0, 3.0]
         let b: [Float16] = [4.0, 5.0, 6.0]
         let result = try XCTUnwrap(a.sqeuclidean(b))
         XCTAssertEqual(result, 27.0, accuracy: 0.01)
     }
+#endif
 
     func testSqeuclideanFloat32() throws {
         let a: [Float32] = [1.0, 2.0, 3.0]


### PR DESCRIPTION
Swift packages are built as universal binaries, which include `x86_64` (kind of crazy we don't have control over this in `Package.swift`). However, `Float16` is only available on arm64 macOS.